### PR TITLE
Fix invalid reference to Test::Unit::AssertionFailedError

### DIFF
--- a/lib/fast_context.rb
+++ b/lib/fast_context.rb
@@ -1,5 +1,13 @@
 require 'shoulda/context'
 
+unless defined?(::Test::Unit::AssertionFailedError)
+  module Test
+    module Unit
+      AssertionFailedError = ActiveSupport::TestCase::Assertion
+    end
+  end
+end
+
 module ShouldaContextExtensions
   def self.included(base)
     base.class_eval do


### PR DESCRIPTION
FastContext, which has not been updated in years, refers to
Test::Unit::AssertionFailedError, which no longer exists. This causes
any details about test failures to get swallowed by NameError, making
debugging unittest issues really cumbersome. If AssertionFailedError
is not defined, make it refer to ActiveSupport::TestCase::Assertion,
which is what current Rails version actually throws.